### PR TITLE
Add debouncing to search

### DIFF
--- a/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
+++ b/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./SearchBar.scss";
 import useApi from "../../../hooks/useApi";
 import { getAutocompleteSuggestions } from "../../../service/mapService";
+import useDebounce from "../../../hooks/useDebounce";
 
 interface SearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
     onSearch: (query: string) => void;
@@ -19,6 +20,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
     ...props
 }) => {
     const [query, setQuery] = useState<string>("");
+    const debouncedQuery = useDebounce(query, 300);
 
     const {
         getApiHandler: fetchAutocompleteSuggestions,
@@ -28,13 +30,18 @@ const SearchBar: React.FC<SearchBarProps> = ({
         error: autocompleteSuggestionsError,
     } = useApi<{ key: string; name: string; coordinates: [number, number] }[]>();
 
-    const getAutocompleteSuggestionsHandler = (query: string) => {
-        fetchAutocompleteSuggestions(getAutocompleteSuggestions, query);
+    const getAutocompleteSuggestionsHandler = (value: string) => {
+        fetchAutocompleteSuggestions(getAutocompleteSuggestions, value);
     }
+
+    useEffect(() => {
+        if (debouncedQuery) {
+            getAutocompleteSuggestionsHandler(debouncedQuery);
+        }
+    }, [debouncedQuery]);
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const value = event.target.value;
-        getAutocompleteSuggestionsHandler(value);
         setQuery(value);
     }
 

--- a/MidpointFinder/UI/src/hooks/useDebounce.ts
+++ b/MidpointFinder/UI/src/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
## Summary
- add generic `useDebounce` hook
- fetch autocomplete suggestions only after user stops typing

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd462a088332a2911000835374b3