### PR TITLE
Use icon buttons for travel mode and fix autocomplete endpoint

### DIFF
--- a/MidpointFinder/UI/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/MidpointFinder/UI/src/components/UI/IconButton/CustomIconButton.tsx
@@ -39,6 +39,9 @@ import PortraitIcon from '@mui/icons-material/Portrait';
 import FormatColorFillIcon from '@mui/icons-material/FormatColorFill';
 import FeedbackIcon from '@mui/icons-material/Feedback';
 import { PauseCircleOutline, NorthEast, Moving, PersonAddAlt } from '@mui/icons-material';
+import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
+import DirectionsBikeIcon from '@mui/icons-material/DirectionsBike';
+import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
 
 // Define the icon map
 const iconMap = {
@@ -84,6 +87,9 @@ const iconMap = {
     portrait: PortraitIcon,
     formatColorFill: FormatColorFillIcon,
     feedback: FeedbackIcon,
+    directionsCar: DirectionsCarIcon,
+    directionsBike: DirectionsBikeIcon,
+    directionsWalk: DirectionsWalkIcon,
 };
 
 // Valid keys for the icon map

--- a/MidpointFinder/UI/src/components/UI/TravelModeSelector.scss
+++ b/MidpointFinder/UI/src/components/UI/TravelModeSelector.scss
@@ -1,0 +1,5 @@
+.travel-mode-selector {
+  display: flex;
+  gap: 0.5rem;
+}
+

--- a/MidpointFinder/UI/src/components/UI/TravelModeSelector.tsx
+++ b/MidpointFinder/UI/src/components/UI/TravelModeSelector.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import CustomIconButton from "./IconButton/CustomIconButton";
+import "./TravelModeSelector.scss";
 
 interface TravelModeSelectorProps {
   value: string;
@@ -6,14 +8,26 @@ interface TravelModeSelectorProps {
   className?: string;
 }
 
+const modes = [
+  { value: "driving-car", icon: "directionsCar" },
+  { value: "cycling-regular", icon: "directionsBike" },
+  { value: "foot-walking", icon: "directionsWalk" },
+];
+
 const TravelModeSelector: React.FC<TravelModeSelectorProps> = ({ value, onChange, className }) => {
   return (
-    <select className={className} value={value} onChange={(e) => onChange(e.target.value)}>
-      <option value="driving-car">Driving</option>
-      <option value="cycling-regular">Cycling</option>
-      <option value="foot-walking">Walking</option>
-    </select>
+    <div className={`travel-mode-selector ${className ?? ""}`}>
+      {modes.map((mode) => (
+        <CustomIconButton
+          key={mode.value}
+          icon={mode.icon}
+          color={value === mode.value ? "primary" : "default"}
+          onClick={() => onChange(mode.value)}
+        />
+      ))}
+    </div>
   );
 };
 
 export default TravelModeSelector;
+

--- a/MidpointFinder/UI/src/service/mapService.ts
+++ b/MidpointFinder/UI/src/service/mapService.ts
@@ -15,6 +15,6 @@ export function getCoordFromString(coordString: string): Promise<{ status: numbe
     return axios.get(`http://localhost:8081/api/getCoordinatesFromLocation/${coordString}`)
 }
 
-export function getAutocompleteSuggestions(coordString: string) { 
-    return axios.get(`http://localhost:8081/api/getAutocompleteSuggestions/${coordString}`)
+export function getAutocompleteSuggestions(coordString: string) {
+    return axios.get(`http://localhost:8081/api/getAutoCompleteSuggestions/${coordString}`)
 }


### PR DESCRIPTION
## Summary
- fix autocomplete suggestions path to match backend
- show travel mode choices with MUI icon buttons
- include basic styling for icon selector

## Testing
- `npm test --silent` *(fails: SyntaxError: Unexpected token 'export' from react-leaflet)*


------
https://chatgpt.com/codex/tasks/task_e_68c5ba713bfc833293c850e5958ad0ab