### PR TITLE
Improve search bar autocomplete interactions

### DIFF
--- a/MidpointFinder/UI/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/MidpointFinder/UI/src/components/UI/IconButton/CustomIconButton.tsx
@@ -38,6 +38,8 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import PortraitIcon from '@mui/icons-material/Portrait';
 import FormatColorFillIcon from '@mui/icons-material/FormatColorFill';
 import FeedbackIcon from '@mui/icons-material/Feedback';
+import SearchIcon from '@mui/icons-material/Search';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
 import { PauseCircleOutline, NorthEast, Moving, PersonAddAlt } from '@mui/icons-material';
 import DirectionsCarIcon from '@mui/icons-material/DirectionsCar';
 import DirectionsBikeIcon from '@mui/icons-material/DirectionsBike';
@@ -90,6 +92,8 @@ const iconMap = {
     directionsCar: DirectionsCarIcon,
     directionsBike: DirectionsBikeIcon,
     directionsWalk: DirectionsWalkIcon,
+    search: SearchIcon,
+    autorenew: AutorenewIcon,
 };
 
 // Valid keys for the icon map
@@ -116,12 +120,13 @@ export const IconComponent: React.FC<{
 interface CustomIconButtonProps extends IconButtonProps {
     icon: string;
     className?: string;
+    iconClassName?: string;
 }
 
-const CustomIconButton: React.FC<CustomIconButtonProps> = ({ icon, className, ...props }) => {
+const CustomIconButton: React.FC<CustomIconButtonProps> = ({ icon, className, iconClassName, ...props }) => {
     return (
         <IconButton {...props} className={className}>
-            <IconComponent icon={icon} className={className} />
+            <IconComponent icon={icon} className={iconClassName ?? className} />
         </IconButton>
     );
 };

--- a/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.scss
+++ b/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.scss
@@ -1,4 +1,14 @@
+@import '../../../variables';
+
+.search-bar {
+    position: relative;
+    width: 100%;
+}
+
 .input-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     background-color: rgba(255, 255, 255, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 10px;
@@ -7,8 +17,73 @@
 }
 
 .search-input {
+    flex: 1;
     background: none !important;
     border: none !important;
     outline: none !important;
     margin-bottom: 5px;
+    color: $light-periwinle;
+    font-weight: bold;
+}
+
+.search-input::placeholder {
+    color: $light-periwinle;
+    font-weight: bold;
+    opacity: 1;
+}
+
+.search-icon-button {
+    color: $light-periwinle !important;
+    padding: 4px;
+}
+
+.search-icon {
+    color: $light-periwinle;
+}
+
+.search-icon.loading {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.suggestions-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    width: 100%;
+    max-height: 200px;
+    overflow-y: auto;
+    background-color: rgba(0, 0, 0, 0.8);
+    border-radius: 10px;
+    padding: 8px 0;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.suggestion-item {
+    background: transparent;
+    border: none;
+    color: $light-periwinle;
+    font-weight: bold;
+    padding: 8px 12px;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.suggestion-item:hover,
+.suggestion-item:focus-visible {
+    background-color: rgba(182, 187, 235, 0.2);
+    outline: none;
 }

--- a/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
+++ b/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
@@ -3,6 +3,7 @@ import "./SearchBar.scss";
 import useApi from "../../../hooks/useApi";
 import { getAutocompleteSuggestions } from "../../../service/mapService";
 import useDebounce from "../../../hooks/useDebounce";
+import CustomIconButton from "../IconButton/CustomIconButton";
 
 interface SearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
     onSearch: (query: string) => void;
@@ -13,19 +14,18 @@ interface SearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
 const SearchBar: React.FC<SearchBarProps> = ({
     onSearch,
     className,
-    iconClassName = "search-icon",
+    iconClassName = "",
     onSuggestionClick,
     ...props
 }) => {
     const [query, setQuery] = useState<string>("");
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
     const debouncedQuery = useDebounce(query, 300);
 
     const {
         getApiHandler: fetchAutocompleteSuggestions,
         isLoading: isAutocompleteSuggestionsLoading,
         data: autocompleteSuggestionsData,
-        isSuccess: isAutocompleteSuggestionsSuccess,
-        error: autocompleteSuggestionsError,
     } = useApi<{ name: string; coordinates: [number, number] }[]>();
 
     const getAutocompleteSuggestionsHandler = (value: string) => {
@@ -33,19 +33,47 @@ const SearchBar: React.FC<SearchBarProps> = ({
     }
 
     useEffect(() => {
-        if (debouncedQuery) {
+        if (!debouncedQuery) {
+            setIsMenuOpen(false);
+            return;
+        }
+
+        if (isMenuOpen) {
             getAutocompleteSuggestionsHandler(debouncedQuery);
         }
-    }, [debouncedQuery]);
+    }, [debouncedQuery, isMenuOpen]);
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const value = event.target.value;
         setQuery(value);
+        setIsMenuOpen(!!value.trim());
     }
 
     const handleSearch = () => {
         if (onSearch) onSearch(query);
+        setIsMenuOpen(false);
     }
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            handleSearch();
+        }
+    }
+
+    const handleSuggestionSelect = (suggestion: { name: string; coordinates: [number, number] }) => {
+        setQuery(suggestion.name);
+        onSuggestionClick(suggestion.coordinates);
+        if (onSearch) onSearch(suggestion.name);
+        setIsMenuOpen(false);
+    }
+
+    const shouldRenderSuggestions =
+        isMenuOpen &&
+        !!autocompleteSuggestionsData?.length &&
+        !isAutocompleteSuggestionsLoading;
+
+    const iconClasses = `search-icon ${iconClassName ?? ""} ${isAutocompleteSuggestionsLoading ? "loading" : ""}`.trim();
 
     return (
         <div className={`search-bar ${className ?? ""}`}>
@@ -54,34 +82,35 @@ const SearchBar: React.FC<SearchBarProps> = ({
                     type="text"
                     className="search-input"
                     value={query}
-                    placeholder="Search..."
+                    placeholder="Get Path"
                     onChange={handleInputChange}
+                    onKeyDown={handleKeyDown}
                     {...props}
                 />
-                <span className={iconClassName}>
-                    {isAutocompleteSuggestionsLoading ? (
-                        <span className="loader">⏳</span> // Loader while fetching suggestions
-                    ) : (
-                        "🔍"
-                    )}
-                </span>
+                <CustomIconButton
+                    icon={isAutocompleteSuggestionsLoading ? "autorenew" : "search"}
+                    className="search-icon-button"
+                    iconClassName={iconClasses}
+                    onClick={handleSearch}
+                    aria-label={isAutocompleteSuggestionsLoading ? "Loading suggestions" : "Search"}
+                    disabled={isAutocompleteSuggestionsLoading}
+                />
             </div>
             {/* Autocomplete Suggestions Dropdown */}
-            {autocompleteSuggestionsData && autocompleteSuggestionsData.length > 0 && (
-                <ul className="suggestions-dropdown">
+            {shouldRenderSuggestions && (
+                <div className="suggestions-dropdown" role="listbox">
                     {autocompleteSuggestionsData.map((suggestion, idx) => (
-                        <li
+                        <button
                             key={`${suggestion.name}-${idx}`}
+                            type="button"
                             className="suggestion-item"
-                            onClick={() => {
-                                setQuery(suggestion.name);
-                                onSuggestionClick(suggestion.coordinates);
-                            }}
+                            onClick={() => handleSuggestionSelect(suggestion)}
+                            role="option"
                         >
                             {suggestion.name}
-                        </li>
+                        </button>
                     ))}
-                </ul>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
## Summary
- replace emoji-based search and loading icons with MUI icons driven through CustomIconButton
- rework the search bar autocomplete menu to float with a scrollable height and trigger callbacks on option click
- align search input placeholder/value styling with the "Get Path" button palette

## Testing
- npm test -- --watchAll=false *(fails: react-leaflet ESM build is not transformed for Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0f5ef5788332a088fc669a86b099