### PR TITLE
Mark selected autocomplete locations on map

### DIFF
--- a/MidpointFinder/UI/src/App.tsx
+++ b/MidpointFinder/UI/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import styles from './App.module.scss';
 import MapComponent from './components/MapComponent';
-import SearchBar from './components/UI/SearchBar/SearchBar';
+import SearchBar, { AutocompleteSuggestion } from './components/UI/SearchBar/SearchBar';
 import useApi from './hooks/useApi';
 import { getCoordFromString } from './service/mapService';
 
@@ -46,13 +46,19 @@ function App() {
     fetchCoordFromString(getCoordFromString, coordString)
   }
 
-  const onSuggestionClick = (id: string, suggestionCoord: [number, number]) => {
+  const onSuggestionClick = (id: string, suggestion: AutocompleteSuggestion) => {
+    const coordinates: [number, number] = [
+      suggestion.coordinates[0],
+      suggestion.coordinates[1],
+    ];
+
     setSearchBarId(id);
-    updateSearchValue(id, formatCoordinates(suggestionCoord));
+    updateSearchValue(id, suggestion.name);
+
     if (id === "sb-1") {
-      setStartPoint1(suggestionCoord);
+      setStartPoint1(coordinates);
     } else if (id === "sb-2") {
-      setStartPoint2(suggestionCoord);
+      setStartPoint2(coordinates);
     }
   }
 

--- a/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
+++ b/MidpointFinder/UI/src/components/UI/SearchBar/SearchBar.tsx
@@ -5,11 +5,16 @@ import { getAutocompleteSuggestions } from "../../../service/mapService";
 import useDebounce from "../../../hooks/useDebounce";
 import CustomIconButton from "../IconButton/CustomIconButton";
 
+export interface AutocompleteSuggestion {
+    name: string;
+    coordinates: [number, number];
+}
+
 interface SearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
     searchBarId: string;
     onSearch: (query: string) => void;
     iconClassName?: string;
-    onSuggestionClick: (searchBarId: string, suggestion: [number, number]) => void;
+    onSuggestionClick: (searchBarId: string, suggestion: AutocompleteSuggestion) => void;
     value?: string;
     onValueChange?: (value: string) => void;
 }
@@ -33,7 +38,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         getApiHandler: fetchAutocompleteSuggestions,
         isLoading: isAutocompleteSuggestionsLoading,
         data: autocompleteSuggestionsData,
-    } = useApi<{ name: string; coordinates: [number, number] }[]>();
+    } = useApi<AutocompleteSuggestion[]>();
 
     const getAutocompleteSuggestionsHandler = (value: string) => {
         fetchAutocompleteSuggestions(getAutocompleteSuggestions, value);
@@ -78,15 +83,22 @@ const SearchBar: React.FC<SearchBarProps> = ({
         }
     }
 
-    const handleSuggestionSelect = (suggestion: { name: string; coordinates: [number, number] }) => {
-        const coordinatesString = `${suggestion.coordinates[0]}, ${suggestion.coordinates[1]}`;
+    const handleSuggestionSelect = (suggestion: AutocompleteSuggestion) => {
+        const normalizedCoordinates: [number, number] = [
+            suggestion.coordinates[0],
+            suggestion.coordinates[1],
+        ];
+
         if (onValueChange) {
-            onValueChange(coordinatesString);
+            onValueChange(suggestion.name);
         } else {
-            setInternalQuery(coordinatesString);
+            setInternalQuery(suggestion.name);
         }
-        onSuggestionClick(searchBarId, suggestion.coordinates);
-        if (onSearch) onSearch(suggestion.name);
+
+        onSuggestionClick(searchBarId, {
+            ...suggestion,
+            coordinates: normalizedCoordinates,
+        });
         setIsMenuOpen(false);
     }
 


### PR DESCRIPTION
## Summary
- add an AutocompleteSuggestion type for the search bar
- populate the search bar with the selected place name and forward the full suggestion to the parent component
- update the app to drop markers directly from autocomplete selections

## Testing
- npm --prefix MidpointFinder/UI test -- --watch=false *(fails: react-leaflet ESM build is unsupported in the Jest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe155e3ac83329e3aa204365aed85